### PR TITLE
30 remove iset history and jset history from tensorci2

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,8 @@ import TensorCrossInterpolation as TCI
 using Test
 using LinearAlgebra
 
+include("test_tensorci2.jl")
+#==
 include("test_with_aqua.jl")
 include("test_with_jet.jl")
 include("test_util.jl")
@@ -21,3 +23,5 @@ include("test_conversion.jl")
 include("test_contraction.jl")
 include("test_integration.jl")
 include("test_globalsearch.jl")
+
+==#

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,8 +2,6 @@ import TensorCrossInterpolation as TCI
 using Test
 using LinearAlgebra
 
-include("test_tensorci2.jl")
-#==
 include("test_with_aqua.jl")
 include("test_with_jet.jl")
 include("test_util.jl")
@@ -23,5 +21,3 @@ include("test_conversion.jl")
 include("test_contraction.jl")
 include("test_integration.jl")
 include("test_globalsearch.jl")
-
-==#

--- a/test/test_tensorci2.jl
+++ b/test/test_tensorci2.jl
@@ -312,7 +312,12 @@ import QuanticsGrids as QD
             ntry=pivotsearch == :full ? 1 : 10
         )
 
+        # Check that the function is interpolated correctly on the global pivots
         @test sum(abs.([TCI.evaluate(tci, r) - f(r) for r in rindex]) .> abstol) == 0
+
+        # Check that the function is interpolated correctly on randomly chosen points
+        rindex_test = [rand(1:2, R) for _ in 1:100]
+        @test sum(abs.([TCI.evaluate(tci, r) - f(r) for r in rindex_test]) .> abstol) == 0
     end
 
     @testset "insert_global_pivots" begin


### PR DESCRIPTION
* Remove `history` from TCI2.
* Unified implementation for adding external global pivots and internal global pivots