### PR TITLE
updated JET test compatibility cutoff to julia 1.10

### DIFF
--- a/test/test_with_jet.jl
+++ b/test/test_with_jet.jl
@@ -2,7 +2,7 @@ using JET
 import TensorCrossInterpolation as TCI
 
 @testset "JET" begin
-    if VERSION ≥ v"1.9"
+    if VERSION ≥ v"1.10"
         JET.test_package(TCI; target_defined_modules=true)
     end
 end


### PR DESCRIPTION
This updates the tests such that JET tests will only run on Julia 1.10 due to compatibility issues.

See here: https://github.com/JuliaDebug/JuliaInterpreter.jl/issues/648