### PR TITLE
Use `AbstractMatrix` instead of `Matrix` in the `_factorize` function

### DIFF
--- a/src/tensortrain.jl
+++ b/src/tensortrain.jl
@@ -93,7 +93,7 @@ function tensortrain(tci)
 end
 
 function _factorize(
-    A::Matrix{V}, method::Symbol; tolerance::Float64, maxbonddim::Int
+    A::AbstractMatrix{V}, method::Symbol; tolerance::Float64, maxbonddim::Int
 )::Tuple{Matrix{V},Matrix{V},Int} where {V}
     if method === :LU
         factorization = rrlu(A, abstol=tolerance, maxrank=maxbonddim)


### PR DESCRIPTION
JET with Julia v1.11 reports the following errors:

```
  Expression: (JET.report_package)(TensorCrossInterpolation; toplevel_logger = nothing, target_defined_modules = true)
  ═════ 4 possible errors found ═════
  ┌  @ TensorCrossInterpolation /Users/atelier/work/atelierarith/tensor4all/TensorCrossInterpolation.jl/src/tensortrain.jl:138
  │ no matching method found `kwcall(::@NamedTuple{tolerance::Float64, maxbonddim::Int64}, ::typeof(TensorCrossInterpolation._factorize), ::Base.ReshapedArray{_A, 2, Array{T, N}, Tuple{}} where {_A, T, N}, ::Symbol)` (1/2 union split): Core.kwcall(NamedTuple{(:tolerance, :maxbonddim)}(tuple(tolerance::Float64, maxbonddim::Int64)::Tuple{Float64, Int64})::@NamedTuple{tolerance::Float64, maxbonddim::Int64}, TensorCrossInterpolation._factorize, TensorCrossInterpolation.reshape(((tt::TensorCrossInterpolation.TensorTrain).sitetensors::Array{Array{ValueType, N}, 1} where {ValueType, N})[ell]::Array, TensorCrossInterpolation.prod(shapel[TensorCrossInterpolation.:(:)(1, TensorCrossInterpolation.:-(lastindex(shapel)::Int64, 1)::Int64)::UnitRange{Int64}]::Tuple)::Any, shapel[lastindex(shapel)::Int64]::Int64)::Union{Base.ReshapedArray{_A, 2, Array{T, N}, Tuple{}} where {_A, T, N}, Array}, method::Symbol)
  └────────────────────
  ┌  @ TensorCrossInterpolation /Users/atelier/work/atelierarith/tensor4all/TensorCrossInterpolation.jl/src/tensortrain.jl:138
  │ no matching method found `kwcall(::@NamedTuple{tolerance::Float64, maxbonddim::Int64}, ::typeof(TensorCrossInterpolation._factorize), ::Base.ReshapedArray{_A, 2, Array{T, N}, Tuple{}} where {_A, T, N}, ::Symbol)` (1/2 union split): Core.kwcall(NamedTuple{(:tolerance, :maxbonddim)}(tuple(tolerance::Float64, maxbonddim::Int64)::Tuple{Float64, Int64})::@NamedTuple{tolerance::Float64, maxbonddim::Int64}, TensorCrossInterpolation._factorize, TensorCrossInterpolation.reshape(((tt::TensorCrossInterpolation.TensorTrain).sitetensors::Array{Array{ValueType, N}, 1} where {ValueType, N})[ell::Int64]::Array, TensorCrossInterpolation.prod((shapel::NTuple{N, Int64} where N)[TensorCrossInterpolation.:(:)(1, TensorCrossInterpolation.:-(lastindex(shapel::NTuple{N, Int64} where N)::Int64, 1)::Int64)::UnitRange{Int64}]::Tuple)::Any, (shapel::NTuple{N, Int64} where N)[lastindex(shapel::NTuple{N, Int64} where N)::Int64]::Int64)::Union{Base.ReshapedArray{_A, 2, Array{T, N}, Tuple{}} where {_A, T, N}, Array}, method::Symbol)::Tuple{Any, Any, Int64}
  └────────────────────
  ┌  @ TensorCrossInterpolation /Users/atelier/work/atelierarith/tensor4all/TensorCrossInterpolation.jl/src/tensortrain.jl:150
  │ no matching method found `kwcall(::@NamedTuple{tolerance::Float64, maxbonddim::Int64}, ::typeof(TensorCrossInterpolation._factorize), ::Base.ReshapedArray{_A, 2, Array{T, N}, Tuple{}} where {_A, T, N}, ::Symbol)` (1/2 union split): Core.kwcall(NamedTuple{(:tolerance, :maxbonddim)}(tuple(tolerance::Float64, maxbonddim::Int64)::Tuple{Float64, Int64})::@NamedTuple{tolerance::Float64, maxbonddim::Int64}, TensorCrossInterpolation._factorize, TensorCrossInterpolation.reshape(((tt::TensorCrossInterpolation.TensorTrain).sitetensors::Array{Array{ValueType, N}, 1} where {ValueType, N})[ell]::Array, shaper[1]::Int64, TensorCrossInterpolation.prod(shaper[TensorCrossInterpolation.:(:)(2, lastindex(shaper)::Int64)::UnitRange{Int64}]::Tuple)::Any)::Union{Base.ReshapedArray{_A, 2, Array{T, N}, Tuple{}} where {_A, T, N}, Array}, method::Symbol)
  └────────────────────
  ┌  @ TensorCrossInterpolation /Users/atelier/work/atelierarith/tensor4all/TensorCrossInterpolation.jl/src/tensortrain.jl:150
  │ no matching method found `kwcall(::@NamedTuple{tolerance::Float64, maxbonddim::Int64}, ::typeof(TensorCrossInterpolation._factorize), ::Base.ReshapedArray{_A, 2, Array{T, N}, Tuple{}} where {_A, T, N}, ::Symbol)` (1/2 union split): Core.kwcall(NamedTuple{(:tolerance, :maxbonddim)}(tuple(tolerance::Float64, maxbonddim::Int64)::Tuple{Float64, Int64})::@NamedTuple{tolerance::Float64, maxbonddim::Int64}, TensorCrossInterpolation._factorize, TensorCrossInterpolation.reshape(((tt::TensorCrossInterpolation.TensorTrain).sitetensors::Array{Array{ValueType, N}, 1} where {ValueType, N})[ell::Int64]::Array, (shaper::NTuple{N, Int64} where N)[1]::Int64, TensorCrossInterpolation.prod((shaper::NTuple{N, Int64} where N)[TensorCrossInterpolation.:(:)(2, lastindex(shaper::NTuple{N, Int64} where N)::Int64)::UnitRange{Int64}]::Tuple)::Any)::Union{Base.ReshapedArray{_A, 2, Array{T, N}, Tuple{}} where {_A, T, N}, Array}, method::Symbol)::Tuple{Any, Any, Int64}
  └────────────────────

Test Summary: | Fail  Total     Time
JET           |    1      1  1m52.9s
```

if we relax the function signature for `_factorize` from A to B (see below), JET won't report any issues

```julia
# A
function _factorize(
    A::AbstractMatrix{V}, method::Symbol; tolerance::Float64, maxbonddim::Int
)::Tuple{Matrix{V},Matrix{V},Int} where {V}`
```

```julia
# B
function _factorize(
    A::AbstractMatrix{V}, method::Symbol; tolerance::Float64, maxbonddim::Int
)::Tuple{Matrix{V},Matrix{V},Int} where {V}
```

This pull request updates the code to use `AbstractMatrix` instead of `Matrix` in the `_factorize` function in `tensortrain.jl`. This change allows for more flexibility in the type of matrices that can be passed to the function.

