### PR TITLE
add new constructor for TensorCI2 to initialize with local pivots list

### DIFF
--- a/src/tensorci2.jl
+++ b/src/tensorci2.jl
@@ -54,7 +54,7 @@ function TensorCI2{ValueType}(
 end
 
 """
-    Initialize with local pivots list(Iset/Jset).
+    Initialize a TCI2 object with local pivot lists.
 """
 function TensorCI2{ValueType}(
     func::F,

--- a/src/tensorci2.jl
+++ b/src/tensorci2.jl
@@ -54,7 +54,7 @@ function TensorCI2{ValueType}(
 end
 
 """
-    Inherit Iset/Jset from the previous evaluation.
+    Initialize with local pivots list(Iset/Jset).
 """
 function TensorCI2{ValueType}(
     func::F,

--- a/test/test_tensorci2.jl
+++ b/test/test_tensorci2.jl
@@ -393,7 +393,7 @@ import QuanticsGrids as QD
     end
 
 
-    @testset "inherit_local_pivots" begin
+    @testset "initialize_with_local_pivots_list" begin
         Random.seed!(1234)
 
         N = 10
@@ -405,6 +405,8 @@ import QuanticsGrids as QD
         tci, ranks, errors = TCI.crossinterpolate2(Float64, f, localdims; maxbonddim=mbd)
         tci2 = TCI.TensorCI2{Float64}(f, localdims, tci.Iset, tci.Jset)
         @test tci2.maxsamplevalue == tci.maxsamplevalue
+        @test tci2.Iset == tci.Iset
+        @test tci2.Jset == tci.Jset
     end
 
     @testset "crossinterpolate2_ttcache" begin

--- a/test/test_tensorci2.jl
+++ b/test/test_tensorci2.jl
@@ -393,6 +393,20 @@ import QuanticsGrids as QD
     end
 
 
+    @testset "inherit_local_pivots" begin
+        Random.seed!(1234)
+
+        N = 10
+        M = rand(Float64, N, N)
+        f(v) = M[v[1], v[2]] # 2D function
+        localdims = fill(N, 2)
+        mbd = 5
+
+        tci, ranks, errors = TCI.crossinterpolate2(Float64, f, localdims; maxbonddim=mbd)
+        tci2 = TCI.TensorCI2{Float64}(f, localdims, tci.Iset, tci.Jset)
+        @test tci2.maxsamplevalue == tci.maxsamplevalue
+    end
+
     @testset "crossinterpolate2_ttcache" begin
         ValueType = Float64
 


### PR DESCRIPTION
This PR updates `src/tensorci2.jl` to add a new constructor for `TensorCI2` to inherit the local pivots of the previous search.
We also add the trivial testset to `test/test_tensorci2.jl` below:

```
@testset "inherit_local_pivots" begin
        Random.seed!(1234)

        N = 10
        M = rand(Float64, N, N)
        f(v) = M[v[1], v[2]] # 2D function
        localdims = fill(N, 2)
        mbd = 5

        tci, ranks, errors = TCI.crossinterpolate2(Float64, f, localdims; maxbonddim=mbd)
        tci2 = TCI.TensorCI2{Float64}(f, localdims, tci.Iset, tci.Jset)
        @test tci2.maxsamplevalue == tci.maxsamplevalue
    end
```