### PR TITLE
Use fixed-size Integers from BitIntegers for CachedFunction instead o…

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,11 +4,13 @@ authors = ["Ritter.Marc <Ritter.Marc@physik.uni-muenchen.de>, Hiroshi Shinaoka <
 version = "0.9.15"
 
 [deps]
+BitIntegers = "c3b6d118-76ef-56ca-8cc7-ebb389d030a1"
 EllipsisNotation = "da5c29d0-fa7d-589e-88eb-ea29b0a81949"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 
 [compat]
+BitIntegers = "0.3.5"
 EllipsisNotation = "1"
 QuadGK = "2.9"
 julia = "1.6"

--- a/src/TensorCrossInterpolation.jl
+++ b/src/TensorCrossInterpolation.jl
@@ -2,6 +2,7 @@ module TensorCrossInterpolation
 
 using LinearAlgebra
 using EllipsisNotation
+using BitIntegers
 import QuadGK
 
 # To add a method for rank(tci)

--- a/test/test_cachedfunction.jl
+++ b/test/test_cachedfunction.jl
@@ -1,7 +1,7 @@
 using Test
 import TensorCrossInterpolation as TCI
 import TensorCrossInterpolation: BatchEvaluator, MultiIndex
-
+import BitIntegers
 struct TestF <: TCI.BatchEvaluator{Float64}
 end
 
@@ -96,7 +96,7 @@ end
         f(x) = 1.0
         nint = 4
         N = 64 * nint
-        cf = TCI.CachedFunction{Float64,BigInt}(f, fill(2, N))
+        cf = TCI.CachedFunction{Float64,BitIntegers.UInt512}(f, fill(2, N))
         x = ones(Int, N)
         @test cf(x) == 1.0
         @test TCI._key(cf, x) == 0


### PR DESCRIPTION
Use fixed-size Integers from BitIntegers for CachedFunction instead of BigInt.
BigInt is SUPER slow.