### PR TITLE
[codex] Add function-based batched evaluation API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.jl.mem
 /Manifest.toml
 /docs/build/
+/.worktrees/

--- a/docs/plans/2026-04-29-batchedf-design.md
+++ b/docs/plans/2026-04-29-batchedf-design.md
@@ -1,0 +1,67 @@
+# `batchedf` Batch Evaluation Design
+
+## Goal
+
+Replace the inheritance-only batch evaluation API with a function-based API that accepts an explicit batch evaluator, while preserving existing `BatchEvaluator` behavior for compatibility.
+
+## Public API
+
+Add a `batchedf` keyword to TCI2 construction and optimization:
+
+```julia
+crossinterpolate2(T, f, localdims; batchedf=nothing, kwargs...)
+optimize!(tci, f; batchedf=nothing, kwargs...)
+```
+
+`f(indexset)` remains the scalar evaluator. `batchedf(indices)` is optional and, when supplied, is used for batch evaluation.
+
+## Batch Layout
+
+`batchedf` receives `indices::AbstractMatrix{<:Integer}` with shape:
+
+```julia
+(length(localdims), npoints)
+```
+
+Each column is one global multi-index point. The second dimension is the batch dimension. This matches the TreeTCI layout in `tensor4all-rs` and is memory-efficient in Julia because complete points are contiguous columns in column-major storage.
+
+`batchedf` must return an `AbstractVector{T}` with length `npoints`.
+
+## Dispatch Priority
+
+Batch evaluation uses this priority:
+
+1. If `batchedf !== nothing`, assemble the `(n_sites, npoints)` index matrix and call `batchedf`.
+2. Otherwise, if `f isa BatchEvaluator`, use the existing inherited interface.
+3. Otherwise, fall back to scalar `f(indexset)` loops.
+
+`checkbatchevaluatable=true` should accept either `batchedf !== nothing` or `f isa BatchEvaluator`.
+
+## Internal Ordering
+
+For the current TCI2 tensor-fill path, points should be assembled in the same order as the existing result layout:
+
+```julia
+(left, center..., right)
+```
+
+The left index varies fastest, then center grid indices, then right index. This allows the returned values to be reshaped directly to:
+
+```julia
+(length(leftindexset), center_dims..., length(rightindexset))
+```
+
+## Compatibility
+
+The existing `BatchEvaluator`, `ThreadedBatchEvaluator`, and `CachedFunction` behavior should keep working. Documentation should mark the function-based `batchedf` API as the recommended path and describe the inherited API as a compatibility interface.
+
+## Testing
+
+Use TDD. Add failing tests first for:
+
+- `_batchevaluate_dispatch` with `batchedf`, verifying matrix shape, column ordering, and values.
+- `crossinterpolate2(...; batchedf=...)` with a plain scalar `f` and no inherited type.
+- `checkbatchevaluatable=true` accepting `batchedf`.
+- Existing `BatchEvaluator` tests continuing to pass.
+
+Cached batch evaluation can be updated after the core TCI2 path is stable, unless tests show it is required by the new API.

--- a/docs/plans/2026-04-29-batchedf-implementation.md
+++ b/docs/plans/2026-04-29-batchedf-implementation.md
@@ -1,0 +1,369 @@
+# `batchedf` Batch Evaluation Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a function-based batch evaluation API for TCI2 using `batchedf(indices::AbstractMatrix)` with the rightmost dimension as the batch dimension.
+
+**Architecture:** Keep scalar `f(indexset)` as the primary mathematical function, and pass optional `batchedf` through TCI2 optimization and tensor filling. Add a new dispatch path in `src/batcheval.jl` that assembles `(n_sites, npoints)` index matrices and reshapes the returned vector into the existing TCI2 tensor layout, while preserving `BatchEvaluator` compatibility.
+
+**Tech Stack:** Julia, TensorCrossInterpolation.jl, `Test`, existing TCI2 and batch evaluation tests.
+
+---
+
+### Task 1: Add Direct `batchedf` Dispatch Tests
+
+**Files:**
+- Modify: `test/test_batcheval.jl`
+- Modify: `src/batcheval.jl`
+
+**Step 1: Write the failing tests**
+
+Add a new testset inside `@testset "batcheval"`:
+
+```julia
+@testset "batchedf matrix API" begin
+    localdims = [2, 3, 2, 4]
+    leftindexset = [[1], [2]]
+    rightindexset = [[1], [3], [4]]
+    seen_shape = Ref{Tuple{Int,Int}}()
+    seen_indices = Ref{Matrix{Int}}()
+
+    f = x -> sum(x)
+    batchedf = indices -> begin
+        seen_shape[] = size(indices)
+        seen_indices[] = copy(indices)
+        [sum(view(indices, :, p)) for p in axes(indices, 2)]
+    end
+
+    result = TCI._batchevaluate_dispatch(
+        Float64,
+        f,
+        batchedf,
+        localdims,
+        leftindexset,
+        rightindexset,
+        Val(2),
+    )
+
+    ref = [
+        sum(vcat(l, c, cp, r))
+        for l in leftindexset,
+            c in 1:localdims[2],
+            cp in 1:localdims[3],
+            r in rightindexset
+    ]
+
+    @test seen_shape[] == (length(localdims), length(result))
+    @test result ≈ ref
+    @test seen_indices[][:, 1] == [1, 1, 1, 1]
+    @test seen_indices[][:, 2] == [2, 1, 1, 1]
+end
+
+@testset "batchedf validates output length" begin
+    localdims = [2, 2, 2]
+    f = x -> sum(x)
+    bad_batchedf = indices -> ones(Float64, size(indices, 2) - 1)
+
+    @test_throws DimensionMismatch TCI._batchevaluate_dispatch(
+        Float64,
+        f,
+        bad_batchedf,
+        localdims,
+        [[1]],
+        [[1]],
+        Val(1),
+    )
+end
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+julia --project=. test/test_batcheval.jl
+```
+
+Expected: FAIL because `_batchevaluate_dispatch(::Type, f, batchedf, ...)` is not defined.
+
+**Step 3: Implement minimal dispatch**
+
+In `src/batcheval.jl`, add:
+
+```julia
+function _batchevaluate_dispatch(
+    ::Type{V},
+    f,
+    batchedf,
+    localdims::Vector{Int},
+    leftindexset::AbstractVector{MultiIndex},
+    rightindexset::AbstractVector{MultiIndex},
+    ::Val{M},
+)::Array{V,M + 2} where {V,M}
+    if length(leftindexset) * length(rightindexset) == 0
+        return Array{V,M + 2}(undef, ntuple(i -> 0, M + 2)...)
+    end
+
+    nl = length(first(leftindexset))
+    nr = length(first(rightindexset))
+    L = M + nl + nr
+    center_dims = localdims[nl+1:L-nr]
+    npoints = length(leftindexset) * prod(center_dims) * length(rightindexset)
+    indices = Matrix{Int}(undef, L, npoints)
+
+    p = 1
+    for rightindex in rightindexset
+        for cindex in Iterators.product(ntuple(x -> 1:localdims[nl+x], M)...)
+            for leftindex in leftindexset
+                indices[1:nl, p] .= leftindex
+                indices[nl+1:nl+M, p] .= cindex
+                indices[nl+M+1:end, p] .= rightindex
+                p += 1
+            end
+        end
+    end
+
+    values = batchedf(indices)
+    length(values) == npoints || throw(DimensionMismatch("batchedf returned $(length(values)) values for $npoints points"))
+    return reshape(Vector{V}(values), length(leftindexset), center_dims..., length(rightindexset))
+end
+```
+
+Keep the existing fallback methods unchanged.
+
+**Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+julia --project=. test/test_batcheval.jl
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/batcheval.jl test/test_batcheval.jl
+git commit -m "feat: add batchedf matrix dispatch"
+```
+
+### Task 2: Thread `batchedf` Through TCI2
+
+**Files:**
+- Modify: `test/test_tensorci2.jl`
+- Modify: `src/tensorci2.jl`
+
+**Step 1: Write the failing tests**
+
+In `test/test_tensorci2.jl`, add tests near `"checkbatchevaluatable"`:
+
+```julia
+@testset "batchedf keyword" begin
+    localdims = fill(2, 5)
+    f(x) = Float64(sum(x))
+    calls = Ref(0)
+    batchedf = indices -> begin
+        calls[] += 1
+        [Float64(sum(view(indices, :, p))) for p in axes(indices, 2)]
+    end
+
+    tci, ranks, errors = crossinterpolate2(
+        Float64,
+        f,
+        localdims;
+        batchedf,
+        tolerance=1e-12,
+        maxiter=2,
+        checkbatchevaluatable=true,
+    )
+
+    @test calls[] > 0
+    @test evaluate(tci, ones(Int, length(localdims))) ≈ f(ones(Int, length(localdims)))
+end
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+julia --project=. test/test_tensorci2.jl
+```
+
+Expected: FAIL because `batchedf` is an unexpected keyword or `checkbatchevaluatable` still rejects plain `f`.
+
+**Step 3: Implement minimal TCI2 plumbing**
+
+In `src/tensorci2.jl`:
+
+- Add `batchedf=nothing` keyword to `optimize!`.
+- Change `checkbatchevaluatable` validation to:
+
+```julia
+if checkbatchevaluatable && isnothing(batchedf) && !(f isa BatchEvaluator)
+    error("Function `f` is not batch evaluatable")
+end
+```
+
+- Use a local evaluator:
+
+```julia
+batchf = isnothing(batchedf) ? f : BatchEvaluatorAdapter{ValueType}(f, batchedf, collect(sitedims(tci)))
+```
+
+or add a new wrapper name if clearer.
+
+- Pass `batchf` to `sweep2site!`, `fillsitetensors!`, global pivot search, and error checks where the existing code expects batch-capable evaluation but still needs scalar calls.
+- Add `batchedf=nothing` keyword to `crossinterpolate2` and forward it to `optimize!(tci, f; batchedf, kwargs...)`.
+
+Prefer a wrapper that implements both scalar `f(indexset)` and batch dispatch through `batchedf`.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+julia --project=. test/test_tensorci2.jl
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/tensorci2.jl test/test_tensorci2.jl
+git commit -m "feat: support batchedf in tci2"
+```
+
+### Task 3: Clean Up Adapter Naming And Compatibility
+
+**Files:**
+- Modify: `src/batcheval.jl`
+- Modify: `test/test_batcheval.jl`
+- Modify: `test/test_cachedfunction.jl` if required by failures
+
+**Step 1: Write or adjust compatibility tests**
+
+Ensure existing tests still cover:
+
+```julia
+bf = TCI.makebatchevaluatable(Float64, tbf, localdims)
+@test size(bf(leftindexset, rightindexset, Val(1))) == (2, 3, 2)
+```
+
+Add a direct wrapper test if a new wrapper is introduced:
+
+```julia
+wrapped = TCI.makebatchevaluatable(Float64, f, batchedf, localdims)
+@test TCI.isbatchevaluable(wrapped)
+@test wrapped([1, 1, 1]) == f([1, 1, 1])
+@test wrapped([[1]], [[1]], Val(1)) ≈ reshape(batchedf([1 1; 1 2; 1 1]), 1, 2, 1)
+```
+
+**Step 2: Run focused tests**
+
+Run:
+
+```bash
+julia --project=. test/test_batcheval.jl test/test_cachedfunction.jl
+```
+
+Expected: FAIL if wrapper constructors or `CachedFunction` assumptions are inconsistent.
+
+**Step 3: Refactor implementation**
+
+In `src/batcheval.jl`, keep `makebatchevaluatable(::Type{T}, f, localdims)` unchanged and add:
+
+```julia
+makebatchevaluatable(::Type{T}, f, batchedf, localdims) where {T} = BatchEvaluatorAdapter{T}(f, batchedf, localdims)
+```
+
+Update `BatchEvaluatorAdapter` fields to support optional `batchedf`, or add a separate wrapper if that keeps constructors clearer.
+
+**Step 4: Run focused tests**
+
+Run:
+
+```bash
+julia --project=. test/test_batcheval.jl test/test_cachedfunction.jl
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/batcheval.jl test/test_batcheval.jl test/test_cachedfunction.jl
+git commit -m "refactor: keep batch evaluator compatibility"
+```
+
+### Task 4: Update Documentation
+
+**Files:**
+- Modify: `docs/src/index.md`
+
+**Step 1: Update docs**
+
+In the batch evaluation section, replace the inheritance-first example with:
+
+```julia
+f(indexset) = sum(indexset)
+
+batchedf = indices -> [
+    sum(view(indices, :, p))
+    for p in axes(indices, 2)
+]
+
+tci, ranks, errors = TCI.crossinterpolate2(
+    Float64,
+    f,
+    localdims;
+    batchedf,
+)
+```
+
+Document that `indices` has shape `(length(localdims), npoints)` and each column is one point. Keep a short compatibility note for `BatchEvaluator`.
+
+**Step 2: Run docs-related check if available**
+
+Run:
+
+```bash
+julia --project=. -e 'using Pkg; Pkg.test()'
+```
+
+Expected: PASS. If too slow, at least run all affected tests from prior tasks.
+
+**Step 3: Commit**
+
+```bash
+git add docs/src/index.md
+git commit -m "docs: document batchedf batch evaluation"
+```
+
+### Task 5: Full Verification
+
+**Files:**
+- No source edits expected
+
+**Step 1: Run full test suite**
+
+Run:
+
+```bash
+julia --project=. -e 'using Pkg; Pkg.test()'
+```
+
+Expected: PASS.
+
+**Step 2: Inspect final diff**
+
+Run:
+
+```bash
+git status --short
+git log --oneline -5
+```
+
+Expected: clean worktree and recent commits for design, implementation, compatibility, and docs.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -172,7 +172,7 @@ x = [1, 1, 1, 1]
 ```
 
 ## Batch Evaluation
-By default, TCI2 evaluates the interpolated function one index set at a time. If evaluating several points together is more efficient, pass a separate `batchedf` function to [`crossinterpolate2`](@ref).
+By default, TCI2 evaluates the interpolated function one index set at a time. If evaluating several points together is more efficient, pass a separate in-place `batchedf!` function to [`crossinterpolate2`](@ref).
 
 ```julia
 import TensorCrossInterpolation as TCI
@@ -181,39 +181,40 @@ localdims = [2, 2, 2, 2, 2]
 
 f(indexset) = sum(indexset)
 
-batchedf = indices -> [
-    sum(view(indices, :, p))
+function batchedf!(values, indices)
     for p in axes(indices, 2)
-]
-
-tci, ranks, errors = TCI.crossinterpolate2(
-    Float64,
-    f,
-    localdims;
-    batchedf,
-)
-```
-
-Here `f(indexset)` remains the scalar evaluator. `batchedf(indices)` receives an integer matrix with shape `(length(localdims), npoints)`. Each column is one point to evaluate, so the rightmost/second dimension is the batch dimension. `batchedf` must return one value for each column, in the same order.
-
-The body of `batchedf` can use threads, MPI, vectorized kernels, or an external batched backend. The scalar `f` is still used where TCI2 needs individual values, while `batchedf` is used for batch tensor fills.
-
-For example, if `f` is thread-safe, the batch evaluator can parallelize over the columns:
-
-```julia
-batchedf = indices -> begin
-    values = Vector{Float64}(undef, size(indices, 2))
-    Threads.@threads for p in axes(indices, 2)
-        values[p] = f(collect(view(indices, :, p)))
+        values[p] = sum(view(indices, :, p))
     end
-    values
+    return values
 end
 
 tci, ranks, errors = TCI.crossinterpolate2(
     Float64,
     f,
     localdims;
-    batchedf,
+    batchedf!,
+)
+```
+
+Here `f(indexset)` remains the scalar evaluator. `batchedf!(values, indices)` receives a preallocated output vector and an integer matrix with shape `(length(localdims), npoints)`. Each column is one point to evaluate, so the rightmost/second dimension is the batch dimension. `batchedf!` must write one value for each column to `values[p]`, in the same order. Its return value is ignored, though returning `values` is conventional.
+
+The body of `batchedf!` can use threads, MPI, vectorized kernels, or an external batched backend. The scalar `f` is still used where TCI2 needs individual values, while `batchedf!` is used for batch tensor fills.
+
+For example, if `f` is thread-safe, the batch evaluator can parallelize over the columns:
+
+```julia
+function batchedf!(values, indices)
+    Threads.@threads for p in axes(indices, 2)
+        values[p] = f(collect(view(indices, :, p)))
+    end
+    return values
+end
+
+tci, ranks, errors = TCI.crossinterpolate2(
+    Float64,
+    f,
+    localdims;
+    batchedf!,
 )
 ```
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -171,185 +171,34 @@ x = [1, 1, 1, 1]
 @time cf(x)
 ```
 
-## Batch Evalaution
-By default, in TCI2, the function to be interpolated is evaluated for a single index at a time. However, there may be a need to parallelize the code by evaluating the function across multiple index sets concurrently using several CPU cores. This type of custom optimization can be achieved through batch evaluation.
-
-To utilize this feature, your function must inherit from  `TCI.BatchEvaluator{T}` and supports two additional types of function calls for evaluating $\mathrm{T}$ (one local index) and $\Pi$ tensors (two local indices):
+## Batch Evaluation
+By default, TCI2 evaluates the interpolated function one index set at a time. If evaluating several points together is more efficient, pass a separate `batchedf` function to [`crossinterpolate2`](@ref).
 
 ```julia
 import TensorCrossInterpolation as TCI
-import TensorCrossInterpolation: MultiIndex
-
-struct TestFunction{T} <: TCI.BatchEvaluator{T}
-    localdims::Vector{Int}
-    function TestFunction{T}(localdims) where {T}
-        new{T}(localdims)
-    end
-end
-
-# Evaluation for a single index set
-function (obj::TestFunction{T})(indexset::MultiIndex)::T where {T}
-    return sum(indexset)
-end
-
-
-# Evaluaiton of a T tensor with one local index
-function (obj::TestFunction{T})(leftindexset::Vector{MultiIndex}, rightindexset::Vector{MultiIndex}, ::Val{1})::Array{T,3} where {T}
-    if length(leftindexset) * length(rightindexset) == 0
-        return Array{T,3}(undef, 0, 0, 0, 0)
-    end
-
-    nl = length(leftindexset[1])
-    # This can be parallelized if you want
-    result = [obj(vcat(l, s1, r)) for l in leftindexset, s1 in 1:obj.localdims[nl+1], r in rightindexset]
-    return reshape(result, length(leftindexset), obj.localdims[nl+1], length(rightindexset))
-end
-
-
-# Evaluaiton of a Pi tensor with two local indices
-function (obj::TestFunction{T})(leftindexset::Vector{MultiIndex}, rightindexset::Vector{MultiIndex}, ::Val{2})::Array{T,4} where {T}
-    if length(leftindexset) * length(rightindexset) == 0
-        return Array{T,4}(undef, 0, 0, 0, 0)
-    end
-
-    nl = length(leftindexset[1])
-    # This can be parallelized if you want
-    result = [obj(vcat(l, s1, s2, r)) for l in leftindexset, s1 in 1:obj.localdims[nl+1], s2 in 1:obj.localdims[nl+2], r in rightindexset]
-    return reshape(result, length(leftindexset), obj.localdims[nl+1:nl+2]..., length(rightindexset))
-end
 
 localdims = [2, 2, 2, 2, 2]
-f = TestFunction{Float64}(localdims)
 
-# Compute T tensor
-let
-    leftindexset = [[1, 1, 1], [2, 2, 1], [2, 1, 1]]
-    rightindexset = [[1, 1], [2, 2], [1, 2]]
+f(indexset) = sum(indexset)
 
-    # The returned object has shape of (3, 2, 3)
-    @assert f(leftindexset, rightindexset, Val(1)) ≈ [sum(vcat(l, s1, r)) for l in leftindexset, s1 in 1:localdims[4], r in rightindexset]
-end
+batchedf = indices -> [
+    sum(view(indices, :, p))
+    for p in axes(indices, 2)
+]
 
-# Compute Pi tensor
-let
-    leftindexset = [[1, 1], [2, 2], [2, 1]]
-    rightindexset = [[1, 1], [2, 2], [1, 2]]
-
-    # The returned object has shape of (3, 2, 2, 3)
-    @assert f(leftindexset, rightindexset, Val(2)) ≈ [sum(vcat(l, s1, s2, r)) for l in leftindexset, s1 in 1:localdims[3], s2 in 1:localdims[4], r in rightindexset]
-end
+tci, ranks, errors = TCI.crossinterpolate2(
+    Float64,
+    f,
+    localdims;
+    batchedf,
+)
 ```
 
-`CachedFunction{T}`  can wrap a function inheriting from `BatchEvaluator{T}`. In such cases, `CachedFunction{T}`  caches the results of batch evaluation.
+Here `f(indexset)` remains the scalar evaluator. `batchedf(indices)` receives an integer matrix with shape `(length(localdims), npoints)`. Each column is one point to evaluate, so the rightmost/second dimension is the batch dimension. `batchedf` must return one value for each column, in the same order.
 
-## Batch evaluation + parallelization
-The batch evalution can be combined with parallelization using threads, MPI, etc.
-The following sample code use `Threads` to parallelize function evaluations.
-Note that the function evaluation for a single index set must be thread-safe.
+The body of `batchedf` can use threads, MPI, vectorized kernels, or an external batched backend. The scalar `f` is still used where TCI2 needs individual values, while `batchedf` is used for batch tensor fills.
 
-We can run the code as (with 6 threads):
-
-```Bash
-julia --project=@. -t 6 samplecode.jl
-```
-
-```Julia
-import TensorCrossInterpolation as TCI
-import TensorCrossInterpolation: MultiIndex
-
-struct TestFunction{T} <: TCI.BatchEvaluator{T}
-    localdims::Vector{Int}
-    function TestFunction{T}(localdims) where {T}
-        new{T}(localdims)
-    end
-end
-
-# Evaluation for a single index set (takes 1 millisec)
-function (obj::TestFunction{T})(indexset::MultiIndex)::T where {T}
-    sleep(1e-3)
-    return sum(indexset)
-end
-
-
-# Batch evaluation (loop over all index sets)
-function (obj::TestFunction{T})(leftindexset::Vector{Vector{Int}}, rightindexset::Vector{Vector{Int}}, ::Val{M})::Array{T,M + 2} where {T,M}
-    if length(leftindexset) * length(rightindexset) == 0
-        return Array{T,M+2}(undef, ntuple(i->0, M+2)...)
-    end
-
-    nl = length(first(leftindexset))
-
-    t = time_ns()
-    cindexset = vec(collect(Iterators.product(ntuple(i->1:obj.localdims[nl+i], M)...)))
-    elements = collect(Iterators.product(1:length(leftindexset), 1:length(cindexset), 1:length(rightindexset)))
-    result = Array{T,3}(undef, length(leftindexset), length(cindexset), length(rightindexset))
-    t2 = time_ns()
-
-    Threads.@threads for indices in elements
-        l, c, r = leftindexset[indices[1]], cindexset[indices[2]], rightindexset[indices[3]]
-        result[indices...] = obj(vcat(l, c..., r))
-    end
-    t3 = time_ns()
-    println("Time: ", (t2-t)/1e9, " ", (t3-t2)/1e9)
-    return reshape(result, length(leftindexset), obj.localdims[nl+1:nl+M]..., length(rightindexset))
-end
-
-
-L = 20
-localdims = fill(2, L)
-f = TestFunction{Float64}(localdims)
-
-println("Number of threads: ", Threads.nthreads())
-
-# Compute Pi tensor
-nl = 10
-nr = L - nl - 2
-
-# 20 left index sets, 20 right index sets
-leftindexset = [[rand(1:d) for d in localdims[1:nl]] for _ in 1:20]
-rightindexset = [[rand(1:d) for d in localdims[nl+3:end]] for _ in 1:20]
-
-f(leftindexset, rightindexset, Val(2))
-
-for i in 1:4
-    @time f(leftindexset, rightindexset, Val(2))
-end
-```
-
-If your function is thread-safe, you can parallelize your function readily using `ThreadedBatchEvaluator` as follows (the internal implementation is identical to the sample code shown above):
-
-```Julia
-import TensorCrossInterpolation as TCI
-
-# Evaluation takes 1 millisecond, make sure the function is thread-safe.
-function f(x)
-    sleep(1e-3)
-    return sum(x)
-end
-
-
-L = 20
-localdims = fill(2, L)
-parf = TCI.ThreadedBatchEvaluator{Float64}(f, localdims)
-
-println("Number of threads: ", Threads.nthreads())
-
-# Compute Pi tensor
-nl = 10
-nr = L - nl - 2
-
-# 20 left index sets, 20 right index sets
-leftindexset = [[rand(1:d) for d in localdims[1:nl]] for _ in 1:20]
-rightindexset = [[rand(1:d) for d in localdims[nl+3:end]] for _ in 1:20]
-
-parf(leftindexset, rightindexset, Val(2))
-
-for i in 1:4
-    @time parf(leftindexset, rightindexset, Val(2))
-end
-```
-
-You can simply pass the wrapped function `parf` to `crossinterpolate2`.
+For compatibility, the inherited `TCI.BatchEvaluator{T}` API is still supported, along with wrappers such as `TCI.ThreadedBatchEvaluator{T}` and `CachedFunction{T}`. New code should prefer the function-based `batchedf` keyword unless it already has a `BatchEvaluator` implementation.
 
 ## Global pivot finder 
 A each TCI2 sweep, we can find the index sets with high interpolation error and add them to the TCI2 object.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -198,7 +198,24 @@ Here `f(indexset)` remains the scalar evaluator. `batchedf(indices)` receives an
 
 The body of `batchedf` can use threads, MPI, vectorized kernels, or an external batched backend. The scalar `f` is still used where TCI2 needs individual values, while `batchedf` is used for batch tensor fills.
 
-For compatibility, the inherited `TCI.BatchEvaluator{T}` API is still supported, along with wrappers such as `TCI.ThreadedBatchEvaluator{T}` and `CachedFunction{T}`. New code should prefer the function-based `batchedf` keyword unless it already has a `BatchEvaluator` implementation.
+For example, if `f` is thread-safe, the batch evaluator can parallelize over the columns:
+
+```julia
+batchedf = indices -> begin
+    values = Vector{Float64}(undef, size(indices, 2))
+    Threads.@threads for p in axes(indices, 2)
+        values[p] = f(collect(view(indices, :, p)))
+    end
+    values
+end
+
+tci, ranks, errors = TCI.crossinterpolate2(
+    Float64,
+    f,
+    localdims;
+    batchedf,
+)
+```
 
 ## Global pivot finder 
 A each TCI2 sweep, we can find the index sets with high interpolation error and add them to the TCI2 object.

--- a/src/batcheval.jl
+++ b/src/batcheval.jl
@@ -1,12 +1,14 @@
 """
 Wrap any function to support batch evaluation.
 """
-struct BatchEvaluatorAdapter{T} <: BatchEvaluator{T}
-    f::Function
+struct BatchEvaluatorAdapter{T,F,B} <: BatchEvaluator{T}
+    f::F
+    batchedf::B
     localdims::Vector{Int}
 end
 
-makebatchevaluatable(::Type{T}, f, localdims) where {T} = BatchEvaluatorAdapter{T}(f, localdims)
+makebatchevaluatable(::Type{T}, f, localdims; batchedf=nothing) where {T} =
+    BatchEvaluatorAdapter{T,typeof(f),typeof(batchedf)}(f, batchedf, localdims)
 
 function (bf::BatchEvaluatorAdapter{T})(indexset::MultiIndex)::T where T
     bf.f(indexset)
@@ -19,6 +21,9 @@ function (bf::BatchEvaluatorAdapter{T})(
 )::Array{T,M + 2} where {T,M}
     if length(leftindexset) * length(rightindexset) == 0
         return Array{T,M + 2}(undef, ntuple(d -> 0, M + 2)...)
+    end
+    if !isnothing(bf.batchedf)
+        return _batchevaluate_dispatch(T, bf.f, bf.batchedf, bf.localdims, leftindexset, rightindexset, Val(M))
     end
     return _batchevaluate_dispatch(T, bf.f, bf.localdims, leftindexset, rightindexset, Val(M))
 end

--- a/src/batcheval.jl
+++ b/src/batcheval.jl
@@ -1,41 +1,18 @@
-"""
-Wrap any function to support batch evaluation.
-"""
-struct BatchEvaluatorAdapter{T,F,B} <: BatchEvaluator{T}
+struct _BatchedFunction{F,B} <: Function
     f::F
     batchedf::B
     localdims::Vector{Int}
 end
 
-makebatchevaluatable(::Type{T}, f, localdims; batchedf=nothing) where {T} =
-    BatchEvaluatorAdapter{T,typeof(f),typeof(batchedf)}(f, batchedf, localdims)
-
-makebatchevaluatable(::Type{T}, f, batchedf, localdims) where {T} =
-    makebatchevaluatable(T, f, localdims; batchedf)
-
-function (bf::BatchEvaluatorAdapter{T})(indexset::MultiIndex)::T where T
+function (bf::_BatchedFunction)(indexset::MultiIndex)
     bf.f(indexset)
 end
 
-function (bf::BatchEvaluatorAdapter{T})(
-    leftindexset::AbstractVector{MultiIndex},
-    rightindexset::AbstractVector{MultiIndex},
-    ::Val{M}
-)::Array{T,M + 2} where {T,M}
-    if length(leftindexset) * length(rightindexset) == 0
-        return Array{T,M + 2}(undef, ntuple(d -> 0, M + 2)...)
-    end
-    if !isnothing(bf.batchedf)
-        return _batchevaluate_dispatch(T, bf.f, bf.batchedf, bf.localdims, leftindexset, rightindexset, Val(M))
-    end
-    return _batchevaluate_dispatch(T, bf.f, bf.localdims, leftindexset, rightindexset, Val(M))
-end
-
-
 """
 This file contains functions for evaluating a function on a batch of indices mainly for TensorCI2.
-If the function supports batch evaluation, then it should implement the `BatchEvaluator` interface.
-Otherwise, the function is evaluated on each index individually using the usual function call syntax and loops.
+If `batchedf` is supplied, it is called with an integer matrix whose columns are
+global index sets. Otherwise, the function is evaluated on each index
+individually using the usual function call syntax and loops.
 """
 function _batchevaluate_dispatch(
     ::Type{V},
@@ -66,6 +43,17 @@ function _batchevaluate_dispatch(
         end
     end
     return reshape(result, length(leftindexset), localdims[nl+1:L-nr]..., length(rightindexset))
+end
+
+function _batchevaluate_dispatch(
+    ::Type{V},
+    bf::_BatchedFunction,
+    localdims::Vector{Int},
+    leftindexset::AbstractVector{MultiIndex},
+    rightindexset::AbstractVector{MultiIndex},
+    ::Val{M})::Array{V,M + 2} where {V,M}
+
+    return _batchevaluate_dispatch(V, bf.f, bf.batchedf, localdims, leftindexset, rightindexset, Val(M))
 end
 
 function _batchevaluate_dispatch(
@@ -103,62 +91,4 @@ function _batchevaluate_dispatch(
         throw(DimensionMismatch("batchedf returned $(length(values)) values for $npoints points"))
     end
     return Array{V,M + 2}(reshape(values, result_dims))
-end
-
-
-"""
-Calling `batchevaluate` on a function that supports batch evaluation will dispatch to this function.
-"""
-function _batchevaluate_dispatch(
-    ::Type{V},
-    f::BatchEvaluator{V},
-    localdims::Vector{Int},
-    Iset::Vector{MultiIndex},
-    Jset::Vector{MultiIndex},
-    ::Val{M}
-)::Array{V,M + 2} where {V,M}
-    if length(Iset) * length(Jset) == 0
-        return Array{V,M + 2}(undef, ntuple(i -> 0, M + 2)...)
-    end
-    N = length(localdims)
-    nl = length(first(Iset))
-    nr = length(first(Jset))
-    ncent = N - nl - nr
-    return f(Iset, Jset, Val(ncent))
-end
-
-
-@doc """
-ThreadedBatchEvaluator{T} is a wrapper for a function that supports batch evaluation parallelized over the index sets using threads.
-The function to be wrapped must be thread-safe.
-"""
-struct ThreadedBatchEvaluator{T} <: BatchEvaluator{T}
-    f::Function
-    localdims::Vector{Int}
-    function ThreadedBatchEvaluator{T}(f, localdims) where {T}
-        new{T}(f, localdims)
-    end
-end
-
-function (obj::ThreadedBatchEvaluator{T})(indexset::Vector{Int})::T where {T}
-    return obj.f(indexset)
-end
-
-# Batch evaluation (loop over all index sets)
-function (obj::ThreadedBatchEvaluator{T})(leftindexset::Vector{Vector{Int}}, rightindexset::Vector{Vector{Int}}, ::Val{M})::Array{T,M + 2} where {T,M}
-    if length(leftindexset) * length(rightindexset) == 0
-        return Array{T,M+2}(undef, ntuple(i->0, M+2)...)
-    end
-
-    nl = length(first(leftindexset))
-
-    cindexset = vec(collect(Iterators.product(ntuple(i->1:obj.localdims[nl+i], M)...)))
-    elements = collect(Iterators.product(1:length(leftindexset), 1:length(cindexset), 1:length(rightindexset)))
-    result = Array{T,3}(undef, length(leftindexset), length(cindexset), length(rightindexset))
-
-    Threads.@threads for indices in elements
-        l, c, r = leftindexset[indices[1]], cindexset[indices[2]], rightindexset[indices[3]]
-        result[indices...] = obj.f(vcat(l, c..., r))
-    end
-    return reshape(result, length(leftindexset), obj.localdims[nl+1:nl+M]..., length(rightindexset))
 end

--- a/src/batcheval.jl
+++ b/src/batcheval.jl
@@ -60,6 +60,43 @@ function _batchevaluate_dispatch(
     return reshape(result, length(leftindexset), localdims[nl+1:L-nr]..., length(rightindexset))
 end
 
+function _batchevaluate_dispatch(
+    ::Type{V},
+    f,
+    batchedf,
+    localdims::Vector{Int},
+    leftindexset::AbstractVector{MultiIndex},
+    rightindexset::AbstractVector{MultiIndex},
+    ::Val{M})::Array{V,M + 2} where {V,M}
+
+    if length(leftindexset) * length(rightindexset) == 0
+        return Array{V,M + 2}(undef, ntuple(i -> 0, M + 2)...)
+    end
+
+    nl = length(first(leftindexset))
+    nr = length(first(rightindexset))
+    L = M + nl + nr
+    center_dims = localdims[nl+1:L-nr]
+    result_dims = (length(leftindexset), center_dims..., length(rightindexset))
+    npoints = prod(result_dims)
+    indices = Matrix{Int}(undef, L, npoints)
+
+    for (p, cartesian_index) in enumerate(CartesianIndices(result_dims))
+        lindex = leftindexset[cartesian_index[1]]
+        cindex = ntuple(i -> cartesian_index[i+1], M)
+        rindex = rightindexset[cartesian_index[M+2]]
+        indices[1:nl, p] .= lindex
+        indices[nl+1:nl+M, p] .= cindex
+        indices[nl+M+1:end, p] .= rindex
+    end
+
+    values = batchedf(indices)
+    if length(values) != npoints
+        throw(DimensionMismatch("batchedf returned $(length(values)) values for $npoints points"))
+    end
+    return Array{V,M + 2}(reshape(values, result_dims))
+end
+
 
 """
 Calling `batchevaluate` on a function that supports batch evaluation will dispatch to this function.

--- a/src/batcheval.jl
+++ b/src/batcheval.jl
@@ -10,6 +10,9 @@ end
 makebatchevaluatable(::Type{T}, f, localdims; batchedf=nothing) where {T} =
     BatchEvaluatorAdapter{T,typeof(f),typeof(batchedf)}(f, batchedf, localdims)
 
+makebatchevaluatable(::Type{T}, f, batchedf, localdims) where {T} =
+    makebatchevaluatable(T, f, localdims; batchedf)
+
 function (bf::BatchEvaluatorAdapter{T})(indexset::MultiIndex)::T where T
     bf.f(indexset)
 end

--- a/src/batcheval.jl
+++ b/src/batcheval.jl
@@ -1,6 +1,6 @@
 struct _BatchedFunction{F,B} <: Function
     f::F
-    batchedf::B
+    batchedf!::B
     localdims::Vector{Int}
 end
 
@@ -10,9 +10,10 @@ end
 
 """
 This file contains functions for evaluating a function on a batch of indices mainly for TensorCI2.
-If `batchedf` is supplied, it is called with an integer matrix whose columns are
-global index sets. Otherwise, the function is evaluated on each index
-individually using the usual function call syntax and loops.
+If `batchedf!` is supplied, it is called with a preallocated output vector and
+an integer matrix whose columns are global index sets. Otherwise, the function
+is evaluated on each index individually using the usual function call syntax and
+loops.
 """
 function _batchevaluate_dispatch(
     ::Type{V},
@@ -53,13 +54,13 @@ function _batchevaluate_dispatch(
     rightindexset::AbstractVector{MultiIndex},
     ::Val{M})::Array{V,M + 2} where {V,M}
 
-    return _batchevaluate_dispatch(V, bf.f, bf.batchedf, localdims, leftindexset, rightindexset, Val(M))
+    return _batchevaluate_dispatch(V, bf.f, bf.batchedf!, localdims, leftindexset, rightindexset, Val(M))
 end
 
 function _batchevaluate_dispatch(
     ::Type{V},
     f,
-    batchedf,
+    batchedf!,
     localdims::Vector{Int},
     leftindexset::AbstractVector{MultiIndex},
     rightindexset::AbstractVector{MultiIndex},
@@ -86,9 +87,7 @@ function _batchevaluate_dispatch(
         indices[nl+M+1:end, p] .= rindex
     end
 
-    values = batchedf(indices)
-    if length(values) != npoints
-        throw(DimensionMismatch("batchedf returned $(length(values)) values for $npoints points"))
-    end
+    values = Vector{V}(undef, npoints)
+    batchedf!(values, indices)
     return Array{V,M + 2}(reshape(values, result_dims))
 end

--- a/src/cachedfunction.jl
+++ b/src/cachedfunction.jl
@@ -3,9 +3,8 @@ Represents a function that maps ArgType -> ValueType and automatically caches
 function values. A `CachedFunction` object can be called in the same way as the original
 function using the usual function call syntax.
 The type `K` denotes the type of the keys used to cache function values, which could be an integer type. This defaults to `UInt128`. A safer but slower alternative is `BigInt`, which is better suited for functions with a large number of arguments.
-`CachedFunction` does not support batch evaluation of function values.
 """
-struct CachedFunction{ValueType,K<:Union{UInt32,UInt64,UInt128,BigInt,BitIntegers.AbstractBitUnsigned}} <: BatchEvaluator{ValueType}
+struct CachedFunction{ValueType,K<:Union{UInt32,UInt64,UInt128,BigInt,BitIntegers.AbstractBitUnsigned}}
     f::Function
     localdims::Vector{Int}
     cache::Dict{K,ValueType}
@@ -72,22 +71,6 @@ function (cf::CachedFunction{ValueType,K})(
 end
 
 
-function (f::CachedFunction{V,K})(
-    leftindexset::AbstractVector{MultiIndex},
-    rightindexset::AbstractVector{MultiIndex},
-    ::Val{M}
-)::Array{V,M + 2} where {V,K,M}
-    if length(leftindexset) * length(rightindexset) == 0
-        return Array{V,M+2}(undef, ntuple(d->0, M+2)...)
-    end
-    if isbatchevaluable(f.f)
-       return _batcheval_imp_for_batchevaluator(f, leftindexset, rightindexset, Val(M))
-    else
-       return _batcheval_imp_default(f, leftindexset, rightindexset, Val(M))
-    end
-end
-
-
 function _batcheval_imp_default(f::CachedFunction{V,K},
     leftindexset::AbstractVector{MultiIndex},
     rightindexset::AbstractVector{MultiIndex},
@@ -110,63 +93,6 @@ function _batcheval_imp_default(f::CachedFunction{V,K},
             end
         end
     end
-    return result
-end
-
-
-function _batcheval_imp_for_batchevaluator(f::CachedFunction{V,K},
-    leftindexset::AbstractVector{MultiIndex},
-    rightindexset::AbstractVector{MultiIndex},
-    ::Val{M}
-)::Array{V,M + 2} where {V,K,M}
-    if length(leftindexset) * length(rightindexset) == 0
-        return Array{V,M + 2}(undef, ntuple(d -> 0, M + 2)...)
-    end
-    nl = length(first(leftindexset))
-    nr = length(first(rightindexset))
-    L = length(f.localdims)
-
-    result = fill(V(NaN), length(leftindexset), f.localdims[nl+1:L-nr]..., length(rightindexset))
-
-    # Compute the values that are already in the cache, leaving the rest as NaN
-    for (j, rightindex) in enumerate(rightindexset)
-        for k in Iterators.product(ntuple(x->1:f.localdims[nl+x], M)...)
-            for (i, leftindex) in enumerate(leftindexset)
-                indexset = vcat(leftindex, collect(Iterators.flatten(k)), rightindex)
-                _k = _key(f, indexset)
-                if _k ∈ keys(f.cache)
-                    result[i, k..., j] = f.cache[_k]
-                end
-            end
-        end
-    end
-
-    # Compute the values that are not in the cache and store them in the cache
-    leftindexset_ = [leftindex for (i, leftindex) in enumerate(leftindexset) if any(result[i, ..] .=== V(NaN))]
-    rightindexset_ = [rightindex for (j, rightindex) in enumerate(rightindexset) if any(result[..,j] .=== V(NaN))]
-    result_ = f.f(leftindexset_, rightindexset_, Val(M))
-    for (j, rightindex) in enumerate(rightindexset_)
-        for k in Iterators.product(ntuple(x->1:f.localdims[nl+x],M)...)
-            for (i, leftindex) in enumerate(leftindexset_)
-                indexset = vcat(leftindex, collect(Iterators.flatten(k)), rightindex)
-                f.cache[_key(f, indexset)] = result_[i, k..., j]
-            end
-        end
-    end
-
-    # Fill in the rest of the result array
-    for (j, rightindex) in enumerate(rightindexset)
-        for k in Iterators.product(ntuple(x->1:f.localdims[nl+x], M)...)
-            for (i, leftindex) in enumerate(leftindexset)
-                if result[i, k..., j] !== V(NaN)
-                    continue
-                end
-                indexset = vcat(leftindex, collect(Iterators.flatten(k)), rightindex)
-                result[i, k..., j] = f.cache[_key(f, indexset)]
-            end
-        end
-    end
-
     return result
 end
 

--- a/src/cachedtensortrain.jl
+++ b/src/cachedtensortrain.jl
@@ -1,12 +1,9 @@
-abstract type BatchEvaluator{V} <: AbstractTensorTrain{V} end
-
-
 """
     struct TTCache{ValueType}
 
 Cached evalulation of a tensor train. This is useful when the same TT is evaluated multiple times with the same indices. The number of site indices per tensor core can be arbitray irrespective of the number of site indices of the original tensor train.
 """
-struct TTCache{ValueType} <: BatchEvaluator{ValueType}
+struct TTCache{ValueType} <: AbstractTensorTrain{ValueType}
     sitetensors::Vector{Array{ValueType,3}}
     cacheleft::Vector{Dict{MultiIndex,Vector{ValueType}}}
     cacheright::Vector{Dict{MultiIndex,Vector{ValueType}}}
@@ -224,6 +221,3 @@ function (tt::TTCache{V})(
     return batchevaluate(tt, leftindexset, rightindexset, Val(M))
 end
 
-
-isbatchevaluable(f) = false
-isbatchevaluable(f::BatchEvaluator) = true

--- a/src/contraction.jl
+++ b/src/contraction.jl
@@ -2,7 +2,7 @@
 Contraction of two TTOs
 Optionally, the contraction can be done with a function applied to the result.
 """
-struct Contraction{T} <: BatchEvaluator{T}
+struct Contraction{T} <: Function
     mpo::NTuple{2,TensorTrain{T,4}}
     leftcache::Dict{Vector{Tuple{Int,Int}},Matrix{T}}
     rightcache::Dict{Vector{Tuple{Int,Int}},Matrix{T}}

--- a/src/tensorci2.jl
+++ b/src/tensorci2.jl
@@ -682,7 +682,7 @@ Arguments:
 - `globalpivotfinder::Union{AbstractGlobalPivotFinder, Nothing}` is a global pivot finder to use for searching global pivots. Default: `nothing`. If `nothing`, a default global pivot finder is used.
 - `maxnglobalpivot::Int` can be set to `>= 0`. Default: `5`. The maximum number of global pivots to add in each iteration.
 - `strictlynested::Bool` determines whether to preserve partial nesting in the TCI algorithm. Default: `false`.
-- `checkbatchevaluatable::Bool` Check if the function `f` is batch evaluatable. Default: `false`.
+- `checkbatchevaluatable::Bool` Check if `batchedf!` is provided. Default: `false`.
 - `checkconvglobalpivot::Bool` Check if the global pivot finder is converged. Default: `true`. In the future, this will be set to `false` by default.
 
 Arguments (deprecated):
@@ -715,7 +715,7 @@ function optimize!(
     nsearchglobalpivot::Int=5,
     tolmarginglobalsearch::Float64=10.0,
     strictlynested::Bool=false,
-    batchedf=nothing,
+    batchedf! = nothing,
     checkbatchevaluatable::Bool=false,
     checkconvglobalpivot::Bool=true
 ) where {ValueType}
@@ -724,10 +724,10 @@ function optimize!(
     nglobalpivots = Int[]
     local tol::Float64
 
-    if checkbatchevaluatable && isnothing(batchedf)
-        error("Function `f` is not batch evaluatable")
+    if checkbatchevaluatable && isnothing(batchedf!)
+        error("Keyword `batchedf!` must be provided when `checkbatchevaluatable=true`.")
     end
-    feval = isnothing(batchedf) ? f : _BatchedFunction(f, batchedf, tci.localdims)
+    feval = isnothing(batchedf!) ? f : _BatchedFunction(f, batchedf!, tci.localdims)
 
     if nsearchglobalpivot > 0 && nsearchglobalpivot < maxnglobalpivot
         error("nsearchglobalpivot < maxnglobalpivot!")
@@ -947,11 +947,11 @@ function crossinterpolate2(
     f,
     localdims::Union{Vector{Int},NTuple{N,Int}},
     initialpivots::Vector{MultiIndex}=[ones(Int, length(localdims))];
-    batchedf=nothing,
+    batchedf! = nothing,
     kwargs...
 ) where {ValueType,N}
     tci = TensorCI2{ValueType}(f, localdims, initialpivots)
-    ranks, errors = optimize!(tci, f; batchedf, kwargs...)
+    ranks, errors = optimize!(tci, f; batchedf!, kwargs...)
     return tci, ranks, errors
 end
 

--- a/src/tensorci2.jl
+++ b/src/tensorci2.jl
@@ -489,10 +489,10 @@ function _submatrix_batcheval(obj::SubMatrix{T}, f, irows::Vector{Int}, icols::V
 end
 
 
-function _submatrix_batcheval(obj::SubMatrix{T}, f::BatchEvaluator{T}, irows::Vector{Int}, icols::Vector{Int})::Matrix{T} where {T}
+function _submatrix_batcheval(obj::SubMatrix{T}, f::_BatchedFunction, irows::Vector{Int}, icols::Vector{Int})::Matrix{T} where {T}
     Iset = [obj.rows[i] for i in irows]
     Jset = [obj.cols[j] for j in icols]
-    return f(Iset, Jset, Val(0))
+    return _batchevaluate_dispatch(T, f, f.localdims, Iset, Jset, Val(0))
 end
 
 
@@ -724,10 +724,10 @@ function optimize!(
     nglobalpivots = Int[]
     local tol::Float64
 
-    if checkbatchevaluatable && isnothing(batchedf) && !(f isa BatchEvaluator)
+    if checkbatchevaluatable && isnothing(batchedf)
         error("Function `f` is not batch evaluatable")
     end
-    feval = isnothing(batchedf) ? f : makebatchevaluatable(ValueType, f, tci.localdims; batchedf)
+    feval = isnothing(batchedf) ? f : _BatchedFunction(f, batchedf, tci.localdims)
 
     if nsearchglobalpivot > 0 && nsearchglobalpivot < maxnglobalpivot
         error("nsearchglobalpivot < maxnglobalpivot!")

--- a/src/tensorci2.jl
+++ b/src/tensorci2.jl
@@ -715,6 +715,7 @@ function optimize!(
     nsearchglobalpivot::Int=5,
     tolmarginglobalsearch::Float64=10.0,
     strictlynested::Bool=false,
+    batchedf=nothing,
     checkbatchevaluatable::Bool=false,
     checkconvglobalpivot::Bool=true
 ) where {ValueType}
@@ -723,9 +724,10 @@ function optimize!(
     nglobalpivots = Int[]
     local tol::Float64
 
-    if checkbatchevaluatable && !(f isa BatchEvaluator)
+    if checkbatchevaluatable && isnothing(batchedf) && !(f isa BatchEvaluator)
         error("Function `f` is not batch evaluatable")
     end
+    feval = isnothing(batchedf) ? f : makebatchevaluatable(ValueType, f, tci.localdims; batchedf)
 
     if nsearchglobalpivot > 0 && nsearchglobalpivot < maxnglobalpivot
         error("nsearchglobalpivot < maxnglobalpivot!")
@@ -775,7 +777,7 @@ function optimize!(
         end
 
         sweep2site!(
-            tci, f, 2;
+            tci, feval, 2;
             iter1 = 1,
             abstol=abstol,
             maxbonddim=maxbonddim,
@@ -786,7 +788,7 @@ function optimize!(
             fillsitetensors=true
             )
         if verbosity > 0 && length(globalpivots) > 0 && mod(iter, loginterval) == 0
-            abserr = [abs(evaluate(tci, p) - f(p)) for p in globalpivots]
+            abserr = [abs(evaluate(tci, p) - feval(p)) for p in globalpivots]
             nrejections = length(abserr .> abstol)
             if nrejections > 0
                 println("  Rejected $(nrejections) global pivots added in the previous iteration, errors are $(abserr)")
@@ -803,7 +805,7 @@ function optimize!(
         # Find global pivots where the error is too large
         input = GlobalPivotSearchInput(tci)
         globalpivots = finder(
-            input, f, abstol;
+            input, feval, abstol;
             verbosity=verbosity,
             rng=Random.default_rng()
         )
@@ -839,7 +841,7 @@ function optimize!(
     abstol = tol * errornormalization;
     sweep1site!(
         tci,
-        f,
+        feval,
         abstol=abstol,
         maxbonddim=maxbonddim,
     )
@@ -945,10 +947,11 @@ function crossinterpolate2(
     f,
     localdims::Union{Vector{Int},NTuple{N,Int}},
     initialpivots::Vector{MultiIndex}=[ones(Int, length(localdims))];
+    batchedf=nothing,
     kwargs...
 ) where {ValueType,N}
     tci = TensorCI2{ValueType}(f, localdims, initialpivots)
-    ranks, errors = optimize!(tci, f; kwargs...)
+    ranks, errors = optimize!(tci, f; batchedf, kwargs...)
     return tci, ranks, errors
 end
 

--- a/test/test_batcheval.jl
+++ b/test/test_batcheval.jl
@@ -114,13 +114,21 @@ end
     @testset "BatchEvaluator direct batchedf wrapper" begin
         localdims = [1, 2, 1]
         f = x -> sum(x)
-        batchedf = indices -> [sum(view(indices, :, p)) for p in axes(indices, 2)]
+        batchedf_calls = Ref(0)
+        batchedf_indices = Ref{Matrix{Int}}()
+        batchedf = indices -> begin
+            batchedf_calls[] += 1
+            batchedf_indices[] = copy(indices)
+            [100 + p for p in axes(indices, 2)]
+        end
 
         wrapped = TCI.makebatchevaluatable(Float64, f, batchedf, localdims)
 
         @test TCI.isbatchevaluable(wrapped)
         @test wrapped([1, 1, 1]) == f([1, 1, 1])
-        @test wrapped([[1]], [[1]], Val(1)) ≈ reshape(batchedf([1 1; 1 2; 1 1]), 1, 2, 1)
+        @test wrapped([[1]], [[1]], Val(1)) ≈ reshape([101, 102], 1, 2, 1)
+        @test batchedf_calls[] == 1
+        @test batchedf_indices[] == [1 1; 1 2; 1 1]
     end
 
     @testset "ThreadedBatchEvaluator" begin

--- a/test/test_batcheval.jl
+++ b/test/test_batcheval.jl
@@ -34,6 +34,60 @@ end
         @test result ≈ ref
     end
 
+    @testset "batchedf matrix API" begin
+        localdims = [2, 3, 2, 4]
+        leftindexset = [[1], [2]]
+        rightindexset = [[1], [3], [4]]
+        seen_shape = Ref{Tuple{Int,Int}}()
+        seen_indices = Ref{Matrix{Int}}()
+
+        f = x -> sum(x)
+        batchedf = indices -> begin
+            seen_shape[] = size(indices)
+            seen_indices[] = copy(indices)
+            [sum(view(indices, :, p)) for p in axes(indices, 2)]
+        end
+
+        result = TCI._batchevaluate_dispatch(
+            Float64,
+            f,
+            batchedf,
+            localdims,
+            leftindexset,
+            rightindexset,
+            Val(2),
+        )
+
+        ref = [
+            sum(vcat(l, c, cp, r))
+            for l in leftindexset,
+                c in 1:localdims[2],
+                cp in 1:localdims[3],
+                r in rightindexset
+        ]
+
+        @test seen_shape[] == (length(localdims), length(result))
+        @test result ≈ ref
+        @test seen_indices[][:, 1] == [1, 1, 1, 1]
+        @test seen_indices[][:, 2] == [2, 1, 1, 1]
+    end
+
+    @testset "batchedf validates output length" begin
+        localdims = [2, 2, 2]
+        f = x -> sum(x)
+        bad_batchedf = indices -> ones(Float64, size(indices, 2) - 1)
+
+        @test_throws DimensionMismatch TCI._batchevaluate_dispatch(
+            Float64,
+            f,
+            bad_batchedf,
+            localdims,
+            [[1]],
+            [[1]],
+            Val(1),
+        )
+    end
+
     @testset "BatchEvaluator" begin
         tbf = NonBatchEvaluator{Float64}()
 

--- a/test/test_batcheval.jl
+++ b/test/test_batcheval.jl
@@ -111,6 +111,18 @@ end
         @test size(bf(leftindexset, rightindexset, Val(1))) == (2, 3, 2)
     end
 
+    @testset "BatchEvaluator direct batchedf wrapper" begin
+        localdims = [1, 2, 1]
+        f = x -> sum(x)
+        batchedf = indices -> [sum(view(indices, :, p)) for p in axes(indices, 2)]
+
+        wrapped = TCI.makebatchevaluatable(Float64, f, batchedf, localdims)
+
+        @test TCI.isbatchevaluable(wrapped)
+        @test wrapped([1, 1, 1]) == f([1, 1, 1])
+        @test wrapped([[1]], [[1]], Val(1)) ≈ reshape(batchedf([1 1; 1 2; 1 1]), 1, 2, 1)
+    end
+
     @testset "ThreadedBatchEvaluator" begin
         L = 20
         localdims = fill(2, L)

--- a/test/test_batcheval.jl
+++ b/test/test_batcheval.jl
@@ -2,14 +2,13 @@ using Test
 import TensorCrossInterpolation as TCI
 
 
-struct NonBatchEvaluator{T} <: Function end
-
-function (f::NonBatchEvaluator{T})(x::Vector{Int})::T where {T}
-    return sum(x)
-end
-
-
 @testset "batcheval" begin
+    @testset "removed inherited API" begin
+        @test !isdefined(TCI, :BatchEvaluator)
+        @test !isdefined(TCI, :ThreadedBatchEvaluator)
+        @test !isdefined(TCI, :makebatchevaluatable)
+    end
+
     @testset "M=1" begin
         localdims = [2, 2, 2, 2, 2]
         leftindexset = [[1, 1] for _ in 1:100]
@@ -100,43 +99,17 @@ end
         )
     end
 
-    @testset "BatchEvaluator" begin
-        tbf = NonBatchEvaluator{Float64}()
-
-        leftindexset = [[1], [2]]
-        rightindexset = [[1], [2]]
-        localdims = [3, 3, 3, 3]
-
-        bf = TCI.makebatchevaluatable(Float64, tbf, localdims)
-        @test size(bf(leftindexset, rightindexset, Val(1))) == (2, 3, 2)
-    end
-
-    @testset "BatchEvaluator direct batchedf wrapper" begin
-        localdims = [1, 2, 1]
-        f = x -> sum(x)
-        batchedf_calls = Ref(0)
-        batchedf_indices = Ref{Matrix{Int}}()
-        batchedf = indices -> begin
-            batchedf_calls[] += 1
-            batchedf_indices[] = copy(indices)
-            [100 + p for p in axes(indices, 2)]
-        end
-
-        wrapped = TCI.makebatchevaluatable(Float64, f, batchedf, localdims)
-
-        @test TCI.isbatchevaluable(wrapped)
-        @test wrapped([1, 1, 1]) == f([1, 1, 1])
-        @test wrapped([[1]], [[1]], Val(1)) ≈ reshape([101, 102], 1, 2, 1)
-        @test batchedf_calls[] == 1
-        @test batchedf_indices[] == [1 1; 1 2; 1 1]
-    end
-
-    @testset "ThreadedBatchEvaluator" begin
+    @testset "threaded batchedf" begin
         L = 20
         localdims = fill(2, L)
         f = x -> sum(x)
-
-        f = TCI.ThreadedBatchEvaluator{Float64}(f, localdims)
+        batchedf = indices -> begin
+            values = Vector{Float64}(undef, size(indices, 2))
+            Threads.@threads for p in axes(indices, 2)
+                values[p] = sum(view(indices, :, p))
+            end
+            values
+        end
 
         # Compute Pi tensor
         nl = 10
@@ -146,23 +119,29 @@ end
         leftindexset = [[rand(1:d) for d in localdims[1:nl]] for _ in 1:20]
         rightindexset = [[rand(1:d) for d in localdims[nl+3:end]] for _ in 1:20]
 
-        result = f(leftindexset, rightindexset, Val(2))
+        result = TCI._batchevaluate_dispatch(Float64, f, batchedf, localdims, leftindexset, rightindexset, Val(2))
         ref = [sum(vcat(l, c, cp, r)) for l in leftindexset, c in 1:localdims[nl+1], cp in 1:localdims[nl+2], r in rightindexset]
 
         @test result ≈ ref
     end
 
-    @testset "ThreadedBatchEvaluator (from Matsuura)" begin
+    @testset "crossinterpolate2 threaded batchedf" begin
         function f(x)
             sleep(1e-3)
-            return sum(x)
+            return Float64(sum(x))
         end
 
         L = 20
         localdims = fill(2, L)
-        parf = TCI.ThreadedBatchEvaluator{Float64}(f, localdims)
+        batchedf = indices -> begin
+            values = Vector{Float64}(undef, size(indices, 2))
+            Threads.@threads for p in axes(indices, 2)
+                values[p] = f(collect(view(indices, :, p)))
+            end
+            values
+        end
 
-        tci, ranks, errors = TCI.crossinterpolate2(Float64, parf, localdims)
+        tci, ranks, errors = TCI.crossinterpolate2(Float64, f, localdims; batchedf)
 
         tci_ref, ranks_ref, errors_ref = TCI.crossinterpolate2(Float64, f, localdims)
 

--- a/test/test_batcheval.jl
+++ b/test/test_batcheval.jl
@@ -33,25 +33,31 @@ import TensorCrossInterpolation as TCI
         @test result ≈ ref
     end
 
-    @testset "batchedf matrix API" begin
+    @testset "batchedf! matrix API" begin
         localdims = [2, 3, 2, 4]
         leftindexset = [[1], [2]]
         rightindexset = [[1], [3], [4]]
         seen_shape = Ref{Tuple{Int,Int}}()
         seen_indices = Ref{Matrix{Int}}()
+        returned = Ref(false)
 
         f = x -> sum(x)
-        batchedf = indices -> begin
+        function batchedf!(values, indices)
             @test indices isa Matrix{Int}
+            @test values isa Vector{Float64}
             seen_shape[] = size(indices)
             seen_indices[] = copy(indices)
-            [sum(view(indices, :, p)) for p in axes(indices, 2)]
+            for p in axes(indices, 2)
+                values[p] = sum(view(indices, :, p))
+            end
+            returned[] = true
+            return nothing
         end
 
         result = TCI._batchevaluate_dispatch(
             Float64,
             f,
-            batchedf,
+            batchedf!,
             localdims,
             leftindexset,
             rightindexset,
@@ -81,34 +87,37 @@ import TensorCrossInterpolation as TCI
         @test seen_shape[] == (length(localdims), length(result))
         @test result ≈ ref
         @test seen_indices[] == expected_indices
+        @test returned[]
     end
 
-    @testset "batchedf validates output length" begin
-        localdims = [2, 2, 2]
+    @testset "batchedf! ignores return value" begin
+        localdims = [2, 3, 2]
         f = x -> sum(x)
-        bad_batchedf = indices -> ones(Float64, size(indices, 2) - 1)
-
-        @test_throws DimensionMismatch TCI._batchevaluate_dispatch(
+        function batchedf!(values, indices)
+            values .= [100 + p for p in eachindex(values)]
+            return fill(-1.0, length(values))
+        end
+        result = TCI._batchevaluate_dispatch(
             Float64,
             f,
-            bad_batchedf,
+            batchedf!,
             localdims,
             [[1]],
             [[1]],
             Val(1),
         )
+        @test vec(result) == [101.0, 102.0, 103.0]
     end
 
-    @testset "threaded batchedf" begin
+    @testset "threaded batchedf!" begin
         L = 20
         localdims = fill(2, L)
         f = x -> sum(x)
-        batchedf = indices -> begin
-            values = Vector{Float64}(undef, size(indices, 2))
+        function batchedf!(values, indices)
             Threads.@threads for p in axes(indices, 2)
                 values[p] = sum(view(indices, :, p))
             end
-            values
+            return values
         end
 
         # Compute Pi tensor
@@ -119,13 +128,13 @@ import TensorCrossInterpolation as TCI
         leftindexset = [[rand(1:d) for d in localdims[1:nl]] for _ in 1:20]
         rightindexset = [[rand(1:d) for d in localdims[nl+3:end]] for _ in 1:20]
 
-        result = TCI._batchevaluate_dispatch(Float64, f, batchedf, localdims, leftindexset, rightindexset, Val(2))
+        result = TCI._batchevaluate_dispatch(Float64, f, batchedf!, localdims, leftindexset, rightindexset, Val(2))
         ref = [sum(vcat(l, c, cp, r)) for l in leftindexset, c in 1:localdims[nl+1], cp in 1:localdims[nl+2], r in rightindexset]
 
         @test result ≈ ref
     end
 
-    @testset "crossinterpolate2 threaded batchedf" begin
+    @testset "crossinterpolate2 threaded batchedf!" begin
         function f(x)
             sleep(1e-3)
             return Float64(sum(x))
@@ -133,15 +142,14 @@ import TensorCrossInterpolation as TCI
 
         L = 20
         localdims = fill(2, L)
-        batchedf = indices -> begin
-            values = Vector{Float64}(undef, size(indices, 2))
+        function batchedf!(values, indices)
             Threads.@threads for p in axes(indices, 2)
                 values[p] = f(collect(view(indices, :, p)))
             end
             values
         end
 
-        tci, ranks, errors = TCI.crossinterpolate2(Float64, f, localdims; batchedf)
+        tci, ranks, errors = TCI.crossinterpolate2(Float64, f, localdims; batchedf!)
 
         tci_ref, ranks_ref, errors_ref = TCI.crossinterpolate2(Float64, f, localdims)
 

--- a/test/test_batcheval.jl
+++ b/test/test_batcheval.jl
@@ -43,6 +43,7 @@ end
 
         f = x -> sum(x)
         batchedf = indices -> begin
+            @test indices isa Matrix{Int}
             seen_shape[] = size(indices)
             seen_indices[] = copy(indices)
             [sum(view(indices, :, p)) for p in axes(indices, 2)]
@@ -65,11 +66,22 @@ end
                 cp in 1:localdims[3],
                 r in rightindexset
         ]
+        expected_indices = Matrix{Int}(undef, length(localdims), length(result))
+        p = 1
+        for r in rightindexset
+            for cp in 1:localdims[3]
+                for c in 1:localdims[2]
+                    for l in leftindexset
+                        expected_indices[:, p] .= vcat(l, c, cp, r)
+                        p += 1
+                    end
+                end
+            end
+        end
 
         @test seen_shape[] == (length(localdims), length(result))
         @test result ≈ ref
-        @test seen_indices[][:, 1] == [1, 1, 1, 1]
-        @test seen_indices[][:, 2] == [2, 1, 1, 1]
+        @test seen_indices[] == expected_indices
     end
 
     @testset "batchedf validates output length" begin

--- a/test/test_cachedfunction.jl
+++ b/test/test_cachedfunction.jl
@@ -1,47 +1,6 @@
 using Test
 import TensorCrossInterpolation as TCI
-import TensorCrossInterpolation: BatchEvaluator, MultiIndex
 import BitIntegers
-struct TestF <: TCI.BatchEvaluator{Float64}
-end
-
-function (f::TestF)(x::T) where {T}
-    return one(T)
-end
-
-function (obj::TestF)(
-    leftindexset::AbstractVector{MultiIndex},
-    rightindexset::AbstractVector{MultiIndex},
-    ::Val{M}
-)::Array{Float64,M + 2} where {M}
-    if length(leftindexset) * length(rightindexset) == 0
-        return zeros{Float64}(0)
-    end
-
-    nl = length(first(leftindexset))
-    nr = length(first(rightindexset))
-    L = nl + nr + M
-
-    return ones(Float64, length(leftindexset), fill(2, M)..., length(rightindexset))
-end
-
-
-struct TestFunction{T} <: TCI.BatchEvaluator{T}
-    localdims::Vector{Int}
-    function TestFunction{T}(localdims) where {T}
-        new{T}(localdims)
-    end
-end
-
-function (obj::TestFunction{T})(indexset)::T where {T}
-    return sum(indexset)
-end
-
-function (obj::TestFunction{T})(leftindexset, rightindexset, ::Val{M})::Array{T,M + 2} where {T,M}
-    nl = length(first(leftindexset))
-    result = [sum(vcat(l, collect(c), r)) for l in leftindexset, c in Iterators.product((1:d for d in obj.localdims[nl+1:nl+M])...), r in rightindexset]
-    return reshape(result, length(leftindexset), obj.localdims[nl+1:nl+M]..., length(rightindexset))
-end
 
 
 @testset "Cached Function" begin
@@ -56,40 +15,6 @@ end
             @test TCI._key(cf, x) ∈ keys(cf.cache)
             @test cf(x) == f(x) # Second access
         end
-    end
-
-    #==
-    @testset "cache(batcheval)" begin
-        localdims = [2, 2, 2, 2, 2]
-        cf = TCI.CachedFunction{Float64}(TestF(), localdims)
-        x = [1, 1, 1, 1, 1]
-        @test cf(x) == 1.0
-    end
-
-    @testset "cache(non-batcheval)" begin
-        localdims = [2, 2, 2, 2, 2]
-        cf = TCI.CachedFunction{Float64}(x->1.0, localdims)
-        x = [1, 1, 1, 1, 1]
-        @show cf(x)
-        @test cf(x) == 1.0
-        @time cf([[1,1]], [[1,1]], Val(1))
-        @time cf([[1,1]], [[1,1]], Val(1))
-    end
-
-    @testset "cache(non-batcheval)" begin
-    end
-    ==#
-    @testset "cache(batcheval)" for T in [Float64, ComplexF64]
-        localdims = [2, 2, 2, 2, 2]
-        leftindexset = [[1, 1] for _ in 1:100]
-        rightindexset = [[1, 1] for _ in 1:100]
-
-        f = TCI.CachedFunction{T}(TestFunction{T}(localdims), localdims)
-        @assert TCI.isbatchevaluable(f)
-        result = TCI._batchevaluate_dispatch(T, f, localdims, leftindexset, rightindexset, Val(1))
-        ref = [sum(vcat(l, c, r)) for l in leftindexset, c in 1:localdims[3], r in rightindexset]
-
-        @test result ≈ ref
     end
 
     @testset "many bits" begin

--- a/test/test_tensorci2.jl
+++ b/test/test_tensorci2.jl
@@ -52,20 +52,23 @@ import QuanticsGrids as QD
         )
     end
 
-    @testset "batchedf keyword" begin
+    @testset "batchedf! keyword" begin
         localdims = fill(2, 5)
         f(x) = Float64(sum(x))
         calls = Ref(0)
-        batchedf = indices -> begin
+        function batchedf!(values, indices)
             calls[] += 1
-            [Float64(sum(view(indices, :, p))) for p in axes(indices, 2)]
+            for p in axes(indices, 2)
+                values[p] = Float64(sum(view(indices, :, p)))
+            end
+            return values
         end
 
         tci, ranks, errors = crossinterpolate2(
             Float64,
             f,
             localdims;
-            batchedf,
+            batchedf!,
             tolerance=1e-12,
             maxiter=2,
             checkbatchevaluatable=true,

--- a/test/test_tensorci2.jl
+++ b/test/test_tensorci2.jl
@@ -52,6 +52,29 @@ import QuanticsGrids as QD
         )
     end
 
+    @testset "batchedf keyword" begin
+        localdims = fill(2, 5)
+        f(x) = Float64(sum(x))
+        calls = Ref(0)
+        batchedf = indices -> begin
+            calls[] += 1
+            [Float64(sum(view(indices, :, p))) for p in axes(indices, 2)]
+        end
+
+        tci, ranks, errors = crossinterpolate2(
+            Float64,
+            f,
+            localdims;
+            batchedf,
+            tolerance=1e-12,
+            maxiter=2,
+            checkbatchevaluatable=true,
+        )
+
+        @test calls[] > 0
+        @test evaluate(tci, ones(Int, length(localdims))) ≈ f(ones(Int, length(localdims)))
+    end
+
     @testset "trivial MPS(exp): pivotsearch=$pivotsearch" for pivotsearch in [:full, :rook], strictlynested in [false, true], nsearchglobalpivot in [0, 10]
         if nsearchglobalpivot > 0 && strictlynested
             continue


### PR DESCRIPTION
## Summary
- Add `batchedf!(values, indices)` in-place batch evaluation for TCI2, where `indices` has shape `(length(localdims), npoints)` and each column is one point.
- Remove the inherited `BatchEvaluator` / `ThreadedBatchEvaluator` / `makebatchevaluatable` API; `batchedf!` is now the only batch evaluation interface.
- Update tests and docs, including thread-parallel `batchedf!` examples.

## Motivation
The previous inheritance-based design forced libraries that wanted to provide batch evaluation to depend on TCI.jl types just to implement the interface. That extra coupling is awkward for downstream packages and makes interop harder than necessary.

A plain function argument is closer to Julia/Python style: users can pass a closure, a callable object, or a backend-specific function directly, without defining a subtype. This is more explicit at the call site and easier to understand than making `f` secretly batch-capable through inheritance.

The mutating `batchedf!` API also makes allocation ownership clear: TCI.jl allocates the output buffer, and the caller fills it. The layout follows the Torch-style convention of treating the rightmost dimension as the batch dimension. Here `indices[:, p]` is one point, and `axes(indices, 2)` iterates over the batch.

## Breaking Changes
- Removed `BatchEvaluator`, `ThreadedBatchEvaluator`, and `makebatchevaluatable`.
- Removed the non-mutating `batchedf` keyword from this PR branch.
- Batch evaluation is now provided with `crossinterpolate2(...; batchedf!)` and `optimize!(...; batchedf!)`.

## New API Sketch
```julia
import TensorCrossInterpolation as TCI

localdims = [2, 2, 2, 2, 2]

f(indexset) = sum(indexset)

function batchedf!(values, indices)
    for p in axes(indices, 2)
        values[p] = f(view(indices, :, p))
    end
    return values
end

tci, ranks, errors = TCI.crossinterpolate2(
    Float64,
    f,
    localdims;
    batchedf!,
)
```

`batchedf!` receives a preallocated output vector and an integer matrix with shape `(length(localdims), npoints)`. The second dimension is the batch dimension, and each column is one global index set. It must write one value per column to `values[p]` in the same order. Its return value is ignored, though returning `values` is conventional.

Thread-parallel evaluation can be written directly in `batchedf!`:

```julia
function batchedf!(values, indices)
    Threads.@threads for p in axes(indices, 2)
        values[p] = f(view(indices, :, p))
    end
    return values
end
```

## Validation
- `julia --project=. test/test_batcheval.jl` -> 14/14 pass
- `julia --project=. test/test_cachedfunction.jl` -> 104/104 pass
- `julia --project=. test/test_tensorci2.jl` -> 2246/2246 pass
- `julia --project=. -e 'using Pkg; Pkg.test()'` -> full suite passed

## Notes
- Draft PR for review.
